### PR TITLE
Bug Fixes #48 #49 Sync active tabs on back press 

### DIFF
--- a/app/src/main/java/com/sscustombottomnavigation/MainActivity.kt
+++ b/app/src/main/java/com/sscustombottomnavigation/MainActivity.kt
@@ -195,7 +195,7 @@ class MainActivity : AppCompatActivity() {
         binding.bottomNavigation.apply {
             // If you don't pass activeIndex then by default it will take 0 position
             setMenuItems(menuItems, activeIndex)
-            setupWithNavController(navController)
+            setupWithNavController(navController = navController, exitOnBack = false)
 
             // manually set the active item, so from which you can control which position item should be active when it is initialized.
             // onMenuItemClick(4)


### PR DESCRIPTION
Issue https://github.com/SimformSolutionsPvtLtd/SSCustomBottomNavigation/issues/48:
-  Add `show` in `addOnDestinationChangedListener` to highlight the active tab on the back press, also add the parameter `isMenuClicked` in the `show` method to check if reloading the fragment is needed or not.

Issue https://github.com/SimformSolutionsPvtLtd/SSCustomBottomNavigation/issues/49:
-  Add parameter `exitOnBack` in the `setupWithNavController` method, to check whether the app should exit on the back press.